### PR TITLE
Task01_Shaposhnikov

### DIFF
--- a/Shaposhnikov/Task01/gsl.c
+++ b/Shaposhnikov/Task01/gsl.c
@@ -1,0 +1,23 @@
+#include <gsl/gsl_linalg.h>
+
+#include "imp_gsl.h"
+
+double *gsl_implementation(double* matrix_a, double* vector_b, int size)
+{
+    gsl_matrix_view gsl_a = gsl_matrix_view_array(matrix_a, size, size);
+    gsl_vector_view gsl_b = gsl_vector_view_array(vector_b, size);
+    gsl_vector *gsl_x = gsl_vector_alloc(size);
+    int s;
+    
+    gsl_permutation *p = gsl_permutation_alloc(size);
+    gsl_linalg_LU_decomp(&gsl_a.matrix, p, &s);
+    gsl_linalg_LU_solve(&gsl_a.matrix, p, &gsl_b.vector, gsl_x);
+    
+    //gsl_permutation_free(p);
+    double* solution = malloc(sizeof(*solution) * size);
+
+    for (int i = 0; i < size; ++i) 
+        solution[i] = gsl_vector_get(gsl_x, i);
+
+    return solution;
+}

--- a/Shaposhnikov/Task01/imp_gsl.h
+++ b/Shaposhnikov/Task01/imp_gsl.h
@@ -1,0 +1,5 @@
+#pragma once
+
+extern double *gsl_implementation(double* matrix, 
+                            double* vector_b, 
+                            int matrix_size);

--- a/Shaposhnikov/Task01/imp_parallel.h
+++ b/Shaposhnikov/Task01/imp_parallel.h
@@ -1,0 +1,3 @@
+#pragma once
+
+extern double *parallel_sle(double* matrix, double* vector_b, int matrix_size);

--- a/Shaposhnikov/Task01/imp_sequential.h
+++ b/Shaposhnikov/Task01/imp_sequential.h
@@ -1,0 +1,5 @@
+#pragma once
+
+extern double *sequential(double* matrix, 
+                            double* vector_b, 
+                            int matrix_size);

--- a/Shaposhnikov/Task01/main.c
+++ b/Shaposhnikov/Task01/main.c
@@ -1,0 +1,99 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <omp.h>
+#include <time.h>
+
+#include "imp_sequential.h"
+#include "imp_gsl.h"
+#include "imp_parallel.h"
+
+#define EXPERIMENTS_AMOUNT 20
+#define EPS 1e-4
+
+double* init_matrix(int size, double* b) {
+    double *a = malloc(sizeof(*a) * size * size);
+	for (int i = 0; i < size; i++)
+	{
+		srand(i * (size+ 1));
+		for (int j = 0; j < size; j++)
+			a[i * size + j] = rand() % 100 + 1;
+
+		b[i] = rand() % 100 + 1;
+	}
+	return a;
+}
+
+int main(int argc, char *argv[]) {
+    if (argc != 2)
+	{
+		fprintf(stderr, "Incorrect number of arguments. Expected: [size]");
+		exit(1);
+	}
+
+	int matrix_size = atoi(argv[1]);
+	if (matrix_size <= 0) 
+	{
+		fprintf(stderr, "[size] should be more than 0, now is %d", matrix_size);
+		exit(1);
+	}
+
+	double gsl_total_time = 0;
+	double seq_total_time = 0;
+	double parallel_total_time = 0;
+
+	for (int i = 0; i < EXPERIMENTS_AMOUNT; i++)
+	{
+		double *vector_b = malloc(sizeof(*vector_b) * matrix_size);
+		double *matrix = init_matrix(matrix_size, vector_b);
+
+		//both ways as i don't know which one's correct
+		double *matrix_gsl = malloc(sizeof(double*) * matrix_size * matrix_size);
+		double *vector_gsl = malloc(sizeof(*vector_gsl) * matrix_size);
+		double *matrix_seq = malloc(sizeof(double*) * matrix_size * matrix_size);
+		double *vector_seq = malloc(sizeof(*vector_seq) * matrix_size);
+
+		//making 3 sets of data for 3 algorithms
+		memcpy(matrix_gsl, matrix, matrix_size * matrix_size * sizeof( double*));
+		memcpy(matrix_seq, matrix, matrix_size * matrix_size * sizeof( double*));
+		memcpy(vector_gsl, vector_b, matrix_size * sizeof( double*));
+		memcpy(vector_seq, vector_b, matrix_size * sizeof( double*));
+		
+		clock_t start_gsl = clock();
+		double* gsl_res = gsl_implementation(matrix_gsl, vector_gsl, matrix_size);
+		clock_t end_gsl = clock();
+		gsl_total_time += ((double) end_gsl - (double) start_gsl)/ CLOCKS_PER_SEC;
+
+		clock_t start_seq = clock();
+		double* seq_res = sequential(matrix_seq, vector_seq, matrix_size);
+		clock_t end_seq = clock();
+		seq_total_time += ((double) end_seq - (double) start_seq)/ CLOCKS_PER_SEC;
+
+		clock_t start_parallel = clock();
+		double* parallel_res = parallel_sle(matrix, vector_b, matrix_size);
+		clock_t end_parallel = clock();
+		parallel_total_time += ((double) end_parallel - (double) start_parallel)/ CLOCKS_PER_SEC;
+
+		free(matrix);
+		free(vector_b);
+		free(matrix_gsl);
+		free(vector_gsl);
+		free(matrix_seq);
+		free(vector_seq);
+
+		for (int k = 0; k < matrix_size; k++)
+		{
+			if (2*parallel_res[k] - gsl_res[k] - seq_res[k] > EPS)
+			{
+				fprintf(stderr, "Diverging results in different algorithms");
+				exit(3);
+			}
+		}
+	}
+
+	printf("For [size] = %d x %d approximate time:\n", matrix_size, matrix_size);
+	printf("	Gsl implementation: %f \n", gsl_total_time / EXPERIMENTS_AMOUNT);
+	printf("	Sequential implementation: %f \n", seq_total_time / EXPERIMENTS_AMOUNT);
+	printf("	Parallel implementation: %f \n\n", parallel_total_time / EXPERIMENTS_AMOUNT);
+	return 0;
+}

--- a/Shaposhnikov/Task01/parallel_sle.c
+++ b/Shaposhnikov/Task01/parallel_sle.c
@@ -1,0 +1,29 @@
+#include <omp.h>
+#include <stdlib.h> 
+#include "imp_parallel.h"
+
+double *parallel_sle(double* matrix, double* vector_b, int matrix_size)
+{
+    double *answer = malloc(sizeof(*answer) * matrix_size);
+
+	for (int k = 0; k < matrix_size - 1; k++)
+	{
+		double pivot = matrix[k * matrix_size + k];
+		for (int i = k + 1; i < matrix_size; i++)
+		{
+			double lik = matrix[i * matrix_size + k] / pivot;
+			#pragma omp for simd
+			for (int j = k; j < matrix_size; j++)
+				matrix[i * matrix_size + j] -= lik * matrix[k * matrix_size + j];
+			vector_b[i] -= lik * vector_b[k];
+		}
+	}
+	for (int k = matrix_size - 1; k >= 0; k--)
+	{
+		answer[k] = vector_b[k];
+		for (int i = k + 1; i < matrix_size; i++)
+			answer[k] -= matrix[k * matrix_size + i] * answer[i];
+		answer[k] /= matrix[k * matrix_size + k];
+	}
+	return answer;
+}

--- a/Shaposhnikov/Task01/result
+++ b/Shaposhnikov/Task01/result
@@ -1,0 +1,35 @@
+For [size] = 10 x 10 approximate time:
+	Gsl implementation: 0.000003 
+	Sequential implementation: 0.000002 
+	Parallel implementation: 0.000003 
+
+For [size] = 100 x 100 approximate time:
+	Gsl implementation: 0.000244 
+	Sequential implementation: 0.001073 
+	Parallel implementation: 0.001153 
+
+For [size] = 200 x 200 approximate time:
+	Gsl implementation: 0.001782 
+	Sequential implementation: 0.008239 
+	Parallel implementation: 0.008773 
+
+For [size] = 500 x 500 approximate time:
+	Gsl implementation: 0.027433 
+	Sequential implementation: 0.128184 
+	Parallel implementation: 0.132959 
+
+For [size] = 1000 x 1000 approximate time:
+	Gsl implementation: 0.242128 
+	Sequential implementation: 1.025240 
+	Parallel implementation: 1.056797 
+
+For [size] = 2000 x 2000 approximate time:
+	Gsl implementation: 2.341544 
+	Sequential implementation: 8.480387 
+	Parallel implementation: 8.876591 
+
+For [size] = 3000 x 3000 approximate time:
+	Gsl implementation: 7.450241 
+	Sequential implementation: 27.718796 
+	Parallel implementation: 28.959493 
+

--- a/Shaposhnikov/Task01/sequential.c
+++ b/Shaposhnikov/Task01/sequential.c
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+#include "imp_sequential.h"
+
+double *sequential(double *a, double *b, int size)
+{
+	double *x = malloc(sizeof(*x) * size);
+                           
+	// Прямой ход -- O(n^3)
+	for (int k = 0; k < size - 1; k++)
+	{
+		// Исключение x_i из строк k+1...n-1
+		double pivot = a[k * size + k];	
+		for (int i = k + 1; i < size; i++)
+		{
+			// Из уравнения (строки) i вычитается уравнение k
+			double lik = a[i * size + k] / pivot;
+			for (int j = k; j < size; j++)
+				a[i * size + j] -= lik * a[k * size + j];
+			b[i] -= lik * b[k];
+		}
+	}
+	// Обратный ход -- O(n^2)
+	for (int k = size - 1; k >= 0; k--)
+	{
+		x[k] = b[k];
+		for (int i = k + 1; i < size; i++)
+			x[k] -= a[k * size + i] * x[i];
+		x[k] /= a[k * size + k];
+	}
+	return x;
+}

--- a/Shaposhnikov/Task01/test.sh
+++ b/Shaposhnikov/Task01/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+touch result.txt
+
+gcc gsl.c parallel_sle.c sequential.c main.c -o gaussian -lgsl -lgslcblas -fopenmp -O0 -w -Wpedantic
+
+for	size in {10,100,200,500,1000,2000,3000}
+do
+	./gaussian "$size" >> result 
+done


### PR DESCRIPTION
Я запускал по 20 тестов на каждый размер матрицы (с рандомными значениями) от 10 на 10 и до 3000 на 3000, чтобы получить усредненный результат; оптимизация -O0; параллелизация реализована через #pragma omp simd
Выходные данные показывают, что ни последовательное, ни параллельное решение не идут в сравнение с использованием библиотеки gsl. Более того, последовательная реализация отрабатывала быстрее параллельной на всех входных данных (под конец увеличивая отрыв)
Какую мораль можно вынести из такого сравнения? Что не всегда простое прямолинейное распараллеливание приносит плоды, стоит более осознанно относится к такой оптимизации, понимать, где это нужно, а где распараллеливание будет дороже ускорения операции (и на каком устройстве это выполнется, очевидно, играет важную роль).